### PR TITLE
Fix wrong webhook environment variable

### DIFF
--- a/agb/system/cogwheel.py
+++ b/agb/system/cogwheel.py
@@ -37,7 +37,7 @@ def getAPIEndpoint(apiName, process) -> str:
 
 def webhook(text="", dataOverride={}, urlOverride=None) -> bool:
     if not urlOverride:
-        url = os.getenv("WEBHOOK_URL", None)
+        url = os.getenv("WEBHOOK", None)
     else:
         url = urlOverride
     

--- a/alphagamebot.json
+++ b/alphagamebot.json
@@ -4,7 +4,7 @@
     "INVITE_URL": "https://discord.com/oauth2/authorize?client_id=946533554953809930&permissions=1494850219126&integration_type=0&scope=bot%20applications.commands"
 
   },
-  "VERSION": "3.12.6",
+  "VERSION": "3.12.7",
   "ANNOUNCEMENT_URL": "https://static-alphagamebot.alphagame.dev/announcement.txt",
   "POINTS": {
     "MESSAGE": 1,


### PR DESCRIPTION
This pull request includes a small change to the `webhook` function in the `agb/system/cogwheel.py` file. The change updates the environment variable name used to fetch the webhook URL.

* [`agb/system/cogwheel.py`](diffhunk://#diff-0d9a130c367603bc99230dafaf031281b6d7c2bc40d0925a1e4e4183861148efL40-R40): Changed the environment variable from `WEBHOOK_URL` to `WEBHOOK` in the `webhook` function.